### PR TITLE
Replace activepivot by atoti-server

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
   <properties>
     <java.version>21</java.version>
     <spring-boot.version>3.2.10</spring-boot.version>
-    <activepivot.version>6.1.3</activepivot.version>
+    <atoti-server.version>6.1.3</atoti-server.version>
     <springdoc.version>2.3.0</springdoc.version>
 
     <opentelemetry-instrumentation.version>2.9.0</opentelemetry-instrumentation.version>
@@ -69,27 +69,27 @@
     <dependency>
       <groupId>com.activeviam.springboot</groupId>
       <artifactId>excel-addin-starter</artifactId>
-      <version>${activepivot.version}</version>
+      <version>${atoti-server.version}</version>
     </dependency>
     <dependency>
       <groupId>com.activeviam.springboot</groupId>
       <artifactId>atoti-server-apm-starter</artifactId>
-      <version>${activepivot.version}</version>
+      <version>${atoti-server.version}</version>
     </dependency>
     <dependency>
       <groupId>com.activeviam.springboot</groupId>
       <artifactId>atoti-server-starter</artifactId>
-      <version>${activepivot.version}</version>
+      <version>${atoti-server.version}</version>
     </dependency>
     <dependency>
       <groupId>com.activeviam.springboot</groupId>
       <artifactId>atoti-ui-starter</artifactId>
-      <version>${activepivot.version}</version>
+      <version>${atoti-server.version}</version>
     </dependency>
     <dependency>
       <groupId>com.activeviam.springboot</groupId>
       <artifactId>atoti-admin-ui-starter</artifactId>
-      <version>${activepivot.version}</version>
+      <version>${atoti-server.version}</version>
     </dependency>
 
     <!-- Content Server persistence -->
@@ -131,7 +131,7 @@
     <dependency>
       <groupId>com.activeviam</groupId>
       <artifactId>atoti-server-test</artifactId>
-      <version>${activepivot.version}</version>
+      <version>${atoti-server.version}</version>
       <scope>test</scope>
     </dependency>
 


### PR DESCRIPTION
Even if very minimal, we should stop using ActivePivot, particularly when pulling the whole Atoti Server stack